### PR TITLE
Numerous updates

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,6 @@
+FROM puppet/pdk:latest
+
+# [Optional] Uncomment this section to install additional packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,38 @@
+# devcontainer
+
+
+For format details, see https://aka.ms/devcontainer.json. 
+
+For config options, see the README at:
+https://github.com/microsoft/vscode-dev-containers/tree/v0.140.1/containers/puppet
+ 
+``` json
+{
+	"name": "Puppet Development Kit (Community)",
+	"dockerFile": "Dockerfile",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.profiles.linux": {
+			"bash": {
+				"path": "bash",
+			}
+		}
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"puppet.puppet-vscode",
+		"rebornix.Ruby"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "pdk --version",
+}
+```
+
+
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+	"name": "Puppet Development Kit (Community)",
+	"dockerFile": "Dockerfile",
+
+	"settings": {
+		"terminal.integrated.profiles.linux": {
+			"bash": {
+				"path": "bash",
+			}
+		}
+	},
+
+	"extensions": [
+		"puppet.puppet-vscode",
+		"rebornix.Ruby"
+	]
+}

--- a/.fixtures-latest.yml
+++ b/.fixtures-latest.yml
@@ -9,6 +9,6 @@ fixtures:
     archive:
       repo: https://github.com/voxpupuli/puppet-archive.git
     systemd:
-      repo: https://github.com/camptocamp/puppet-systemd.git
+      repo: https://github.com/voxpupuli/puppet-systemd.git
   symlinks:
     etcd: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,9 +9,9 @@ fixtures:
       ref: v6.0.0
     archive:
       repo: https://github.com/voxpupuli/puppet-archive.git
-      ref: v4.0.0
+      ref: v7.0.0
     systemd:
-      repo: https://github.com/camptocamp/puppet-systemd.git
-      ref: 2.0.0
+      repo: https://github.com/voxpupuli/puppet-systemd.git
+      ref: v5.0.0
   symlinks:
     etcd: "#{source_dir}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,39 +15,35 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ruby: 2.5.7
-            puppet: 6
-            fixtures: .fixtures.yml
-            allow_failure: false
-          - ruby: 2.7.0
+          - ruby: 2.7.8
             puppet: 7
             fixtures: .fixtures.yml
             allow_failure: false
-          - ruby: 2.4.9
-            puppet: 5
-            fixtures: .fixtures.yml
-            allow_failure: false
-          - ruby: 2.5.7
-            puppet: 6
+          - ruby: 2.7.8
+            puppet: 7
             fixtures: .fixtures-latest.yml
             allow_failure: true
-          - ruby: 2.7.0
-            puppet: 7
+          - ruby: 3.2.2
+            puppet: 8
+            fixtures: .fixtures.yml
+            allow_failure: false
+          - ruby: 3.2.2
+            puppet: 8
             fixtures: .fixtures-latest.yml
             allow_failure: true
     env:
       BUNDLE_WITHOUT: system_tests:release
       PUPPET_GEM_VERSION: "~> ${{ matrix.puppet }}.0"
-      FACTER_GEM_VERSION: "< 4.0"
       FIXTURES_YML: ${{ matrix.fixtures }}
     name: Puppet ${{ matrix.puppet }} (Ruby ${{ matrix.ruby }} fixtures=${{ matrix.fixtures }})
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+          cache-version: 2
           bundler: '2.1.0'
       - name: Validate
         run: bundle exec rake check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop syntax lint metadata_lint
@@ -59,14 +55,14 @@ jobs:
       fail-fast: false
       matrix:
         set:
-          - "centos-7"
-          - "centos-8"
-          - "debian-9"
-          - "debian-10"
-          - "ubuntu-1804"
+          - "el8"
+          - "el9"
+          - "debian-11"
+          - "ubuntu-2004"
+          - "ubuntu-2204"
         puppet:
-          - "puppet6"
           - "puppet7"
+          - "puppet8"
     env:
       BUNDLE_WITHOUT: development:release
       BEAKER_debug: true
@@ -83,12 +79,13 @@ jobs:
             sudo apt-get remove mysql-server --purge
             sudo apt-get install apparmor-profiles
             sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Setup ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7'
           bundler-cache: true
+          cache-version: 2
           bundler: '2.1.0'
       - name: Run tests
         run: bundle exec rake beaker

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,12 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7'
           bundler-cache: true
+          cache-version: 2
           bundler: '2.1.0'
       - name: Build and Deploy
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@
 .project
 .envrc
 /inventory.yaml
+/spec/fixtures/litmus_inventory.yaml

--- a/.pdkignore
+++ b/.pdkignore
@@ -25,6 +25,7 @@
 .project
 .envrc
 /inventory.yaml
+/spec/fixtures/litmus_inventory.yaml
 /appveyor.yml
 /.fixtures.yml
 /Gemfile
@@ -40,3 +41,5 @@
 /.yardopts
 /spec/
 /.vscode/
+/.sync.yml
+/.devcontainer/

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,2 +1,5 @@
+--no-80chars-check
+--no-140chars-check
+--no-manifest_whitespace_opening_brace_after-check
 --relative
 --fail_on_warnings

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,12 +1,12 @@
 ---
 require:
+- rubocop-performance
 - rubocop-rspec
-- rubocop-i18n
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: '2.1'
+  TargetRubyVersion: '2.5'
   Include:
-  - "./**/*.rb"
+  - "**/*.rb"
   Exclude:
   - bin/*
   - ".vendor/**/*"
@@ -18,16 +18,9 @@ AllCops:
   - "**/Puppetfile"
   - "**/Vagrantfile"
   - "**/Guardfile"
-Metrics/LineLength:
+Layout/LineLength:
   Description: People have wide screens, use them.
   Max: 200
-GetText:
-  Enabled: false
-GetText/DecorateString:
-  Description: We don't want to decorate test output.
-  Exclude:
-  - spec/**/*
-  Enabled: false
 RSpec/BeforeAfterAll:
   Description: Beware of using after(:all) as it may cause state to leak between tests.
     A necessary evil in acceptance testing.
@@ -36,14 +29,13 @@ RSpec/BeforeAfterAll:
 RSpec/HookArgument:
   Description: Prefer explicit :each argument, matching existing module's style
   EnforcedStyle: each
+RSpec/DescribeSymbol:
+  Exclude:
+  - spec/unit/facter/**/*.rb
 Style/BlockDelimiters:
   Description: Prefer braces for chaining. Mostly an aesthetical choice. Better to
     be consistent then.
   EnforcedStyle: braces_for_chaining
-Style/BracesAroundHashParameters:
-  Description: Braces are required by Ruby 2.7. Cop removed from RuboCop v0.80.0.
-    See https://github.com/rubocop-hq/rubocop/pull/7643
-  Enabled: true
 Style/ClassAndModuleChildren:
   Description: Compact style reduces the required amount of indentation.
   EnforcedStyle: compact
@@ -72,40 +64,192 @@ Style/TrailingCommaInArguments:
   Description: Prefer always trailing comma on multiline argument lists. This makes
     diffs, and re-ordering nicer.
   EnforcedStyleForMultiline: comma
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
   Description: Prefer always trailing comma on multiline literals. This makes diffs,
     and re-ordering nicer.
   EnforcedStyleForMultiline: comma
 Style/SymbolArray:
   Description: Using percent style obscures symbolic intent of array's contents.
   EnforcedStyle: brackets
+Layout/FirstHashElementIndentation:
+  Enabled: false
+Performance/RegexpMatch:
+  Enabled: false
 RSpec/MessageSpies:
   EnforcedStyle: receive
+RSpec/NamedSubject:
+  Enabled: false
 Style/Documentation:
   Exclude:
   - lib/puppet/parser/functions/**/*
   - spec/**/*
+Style/HashEachMethods:
+  Enabled: false
 Style/WordArray:
   EnforcedStyle: brackets
+Performance/AncestorsInclude:
+  Enabled: true
+Performance/BigDecimalWithNumericArgument:
+  Enabled: true
+Performance/BlockGivenWithExplicitBlock:
+  Enabled: true
+Performance/CaseWhenSplat:
+  Enabled: true
+Performance/ConstantRegexp:
+  Enabled: true
+Performance/MethodObjectAsBlock:
+  Enabled: true
+Performance/RedundantSortBlock:
+  Enabled: true
+Performance/RedundantStringChars:
+  Enabled: true
+Performance/ReverseFirst:
+  Enabled: true
+Performance/SortReverse:
+  Enabled: true
+Performance/Squeeze:
+  Enabled: true
+Performance/StringInclude:
+  Enabled: true
+Performance/Sum:
+  Enabled: true
 Style/CollectionMethods:
   Enabled: true
 Style/MethodCalledOnDoEndBlock:
   Enabled: true
 Style/StringMethods:
   Enabled: true
-GetText/DecorateFunctionMessage:
+Bundler/InsecureProtocolSource:
   Enabled: false
-GetText/DecorateStringFormattingUsingInterpolation:
+Gemspec/DuplicatedAssignment:
   Enabled: false
-GetText/DecorateStringFormattingUsingPercent:
+Gemspec/OrderedDependencies:
+  Enabled: false
+Gemspec/RequiredRubyVersion:
+  Enabled: false
+Gemspec/RubyVersionGlobalsUsage:
+  Enabled: false
+Layout/ArgumentAlignment:
+  Enabled: false
+Layout/BeginEndAlignment:
+  Enabled: false
+Layout/ClosingHeredocIndentation:
+  Enabled: false
+Layout/EmptyComment:
+  Enabled: false
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+Layout/EmptyLinesAroundArguments:
+  Enabled: false
+Layout/EmptyLinesAroundAttributeAccessor:
   Enabled: false
 Layout/EndOfLine:
   Enabled: false
-Layout/IndentHeredoc:
+Layout/FirstArgumentIndentation:
+  Enabled: false
+Layout/HashAlignment:
+  Enabled: false
+Layout/HeredocIndentation:
+  Enabled: false
+Layout/LeadingEmptyLines:
+  Enabled: false
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: false
+Layout/SpaceInsideArrayLiteralBrackets:
+  Enabled: false
+Layout/SpaceInsideReferenceBrackets:
+  Enabled: false
+Lint/BigDecimalNew:
+  Enabled: false
+Lint/BooleanSymbol:
+  Enabled: false
+Lint/ConstantDefinitionInBlock:
+  Enabled: false
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: false
+Lint/DisjunctiveAssignmentInConstructor:
+  Enabled: false
+Lint/DuplicateElsifCondition:
+  Enabled: false
+Lint/DuplicateRequire:
+  Enabled: false
+Lint/DuplicateRescueException:
+  Enabled: false
+Lint/EmptyConditionalBody:
+  Enabled: false
+Lint/EmptyFile:
+  Enabled: false
+Lint/ErbNewArguments:
+  Enabled: false
+Lint/FloatComparison:
+  Enabled: false
+Lint/HashCompareByIdentity:
+  Enabled: false
+Lint/IdentityComparison:
+  Enabled: false
+Lint/InterpolationCheck:
+  Enabled: false
+Lint/MissingCopEnableDirective:
+  Enabled: false
+Lint/MixedRegexpCaptureTypes:
+  Enabled: false
+Lint/NestedPercentLiteral:
+  Enabled: false
+Lint/NonDeterministicRequireOrder:
+  Enabled: false
+Lint/OrderedMagicComments:
+  Enabled: false
+Lint/OutOfRangeRegexpRef:
+  Enabled: false
+Lint/RaiseException:
+  Enabled: false
+Lint/RedundantCopEnableDirective:
+  Enabled: false
+Lint/RedundantRequireStatement:
+  Enabled: false
+Lint/RedundantSafeNavigation:
+  Enabled: false
+Lint/RedundantWithIndex:
+  Enabled: false
+Lint/RedundantWithObject:
+  Enabled: false
+Lint/RegexpAsCondition:
+  Enabled: false
+Lint/ReturnInVoidContext:
+  Enabled: false
+Lint/SafeNavigationConsistency:
+  Enabled: false
+Lint/SafeNavigationWithEmpty:
+  Enabled: false
+Lint/SelfAssignment:
+  Enabled: false
+Lint/SendWithMixinArgument:
+  Enabled: false
+Lint/ShadowedArgument:
+  Enabled: false
+Lint/StructNewOverride:
+  Enabled: false
+Lint/ToJSON:
+  Enabled: false
+Lint/TopLevelReturnWithArgument:
+  Enabled: false
+Lint/TrailingCommaInAttributeDeclaration:
+  Enabled: false
+Lint/UnreachableLoop:
+  Enabled: false
+Lint/UriEscapeUnescape:
+  Enabled: false
+Lint/UriRegexp:
+  Enabled: false
+Lint/UselessMethodDefinition:
+  Enabled: false
+Lint/UselessTimes:
   Enabled: false
 Metrics/AbcSize:
   Enabled: false
 Metrics/BlockLength:
+  Enabled: false
+Metrics/BlockNesting:
   Enabled: false
 Metrics/ClassLength:
   Enabled: false
@@ -119,19 +263,265 @@ Metrics/ParameterLists:
   Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
+Migration/DepartmentName:
+  Enabled: false
+Naming/AccessorMethodName:
+  Enabled: false
+Naming/BlockParameterName:
+  Enabled: false
+Naming/HeredocDelimiterCase:
+  Enabled: false
+Naming/HeredocDelimiterNaming:
+  Enabled: false
+Naming/MemoizedInstanceVariableName:
+  Enabled: false
+Naming/MethodParameterName:
+  Enabled: false
+Naming/RescuedExceptionsVariableName:
+  Enabled: false
+Naming/VariableNumber:
+  Enabled: false
+Performance/BindCall:
+  Enabled: false
+Performance/DeletePrefix:
+  Enabled: false
+Performance/DeleteSuffix:
+  Enabled: false
+Performance/InefficientHashSearch:
+  Enabled: false
+Performance/UnfreezeString:
+  Enabled: false
+Performance/UriDefaultParser:
+  Enabled: false
+RSpec/Be:
+  Enabled: false
+RSpec/Capybara/CurrentPathExpectation:
+  Enabled: false
+RSpec/Capybara/FeatureMethods:
+  Enabled: false
+RSpec/Capybara/VisibilityMatcher:
+  Enabled: false
+RSpec/ContextMethod:
+  Enabled: false
+RSpec/ContextWording:
+  Enabled: false
 RSpec/DescribeClass:
+  Enabled: false
+RSpec/EmptyHook:
+  Enabled: false
+RSpec/EmptyLineAfterExample:
+  Enabled: false
+RSpec/EmptyLineAfterExampleGroup:
+  Enabled: false
+RSpec/EmptyLineAfterHook:
   Enabled: false
 RSpec/ExampleLength:
   Enabled: false
-RSpec/MessageExpectation:
+RSpec/ExampleWithoutDescription:
+  Enabled: false
+RSpec/ExpectChange:
+  Enabled: false
+RSpec/ExpectInHook:
+  Enabled: false
+RSpec/FactoryBot/AttributeDefinedStatically:
+  Enabled: false
+RSpec/FactoryBot/CreateList:
+  Enabled: false
+RSpec/FactoryBot/FactoryClassName:
+  Enabled: false
+RSpec/HooksBeforeExamples:
+  Enabled: false
+RSpec/ImplicitBlockExpectation:
+  Enabled: false
+RSpec/ImplicitSubject:
+  Enabled: false
+RSpec/LeakyConstantDeclaration:
+  Enabled: false
+RSpec/LetBeforeExamples:
+  Enabled: false
+RSpec/MissingExampleGroupArgument:
   Enabled: false
 RSpec/MultipleExpectations:
   Enabled: false
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+RSpec/MultipleSubjects:
+  Enabled: false
 RSpec/NestedGroups:
+  Enabled: false
+RSpec/PredicateMatcher:
+  Enabled: false
+RSpec/ReceiveCounts:
+  Enabled: false
+RSpec/ReceiveNever:
+  Enabled: false
+RSpec/RepeatedExampleGroupBody:
+  Enabled: false
+RSpec/RepeatedExampleGroupDescription:
+  Enabled: false
+RSpec/RepeatedIncludeExample:
+  Enabled: false
+RSpec/ReturnFromStub:
+  Enabled: false
+RSpec/SharedExamples:
+  Enabled: false
+RSpec/StubbedMock:
+  Enabled: false
+RSpec/UnspecifiedException:
+  Enabled: false
+RSpec/VariableDefinition:
+  Enabled: false
+RSpec/VoidExpect:
+  Enabled: false
+RSpec/Yield:
+  Enabled: false
+Security/Open:
+  Enabled: false
+Style/AccessModifierDeclarations:
+  Enabled: false
+Style/AccessorGrouping:
   Enabled: false
 Style/AsciiComments:
   Enabled: false
+Style/BisectedAttrAccessor:
+  Enabled: false
+Style/CaseLikeIf:
+  Enabled: false
+Style/ClassEqualityComparison:
+  Enabled: false
+Style/ColonMethodDefinition:
+  Enabled: false
+Style/CombinableLoops:
+  Enabled: false
+Style/CommentedKeyword:
+  Enabled: false
+Style/Dir:
+  Enabled: false
+Style/DoubleCopDisableDirective:
+  Enabled: false
+Style/EmptyBlockParameter:
+  Enabled: false
+Style/EmptyLambdaParameter:
+  Enabled: false
+Style/Encoding:
+  Enabled: false
+Style/EvalWithLocation:
+  Enabled: false
+Style/ExpandPathArguments:
+  Enabled: false
+Style/ExplicitBlockArgument:
+  Enabled: false
+Style/ExponentialNotation:
+  Enabled: false
+Style/FloatDivision:
+  Enabled: false
+Style/FrozenStringLiteralComment:
+  Enabled: false
+Style/GlobalStdStream:
+  Enabled: false
+Style/HashAsLastArrayItem:
+  Enabled: false
+Style/HashLikeCase:
+  Enabled: false
+Style/HashTransformKeys:
+  Enabled: false
+Style/HashTransformValues:
+  Enabled: false
 Style/IfUnlessModifier:
   Enabled: false
+Style/KeywordParametersOrder:
+  Enabled: false
+Style/MinMax:
+  Enabled: false
+Style/MixinUsage:
+  Enabled: false
+Style/MultilineWhenThen:
+  Enabled: false
+Style/NegatedUnless:
+  Enabled: false
+Style/NumericPredicate:
+  Enabled: false
+Style/OptionalBooleanParameter:
+  Enabled: false
+Style/OrAssignment:
+  Enabled: false
+Style/RandomWithOffset:
+  Enabled: false
+Style/RedundantAssignment:
+  Enabled: false
+Style/RedundantCondition:
+  Enabled: false
+Style/RedundantConditional:
+  Enabled: false
+Style/RedundantFetchBlock:
+  Enabled: false
+Style/RedundantFileExtensionInRequire:
+  Enabled: false
+Style/RedundantRegexpCharacterClass:
+  Enabled: false
+Style/RedundantRegexpEscape:
+  Enabled: false
+Style/RedundantSelfAssignment:
+  Enabled: false
+Style/RedundantSort:
+  Enabled: false
+Style/RescueStandardError:
+  Enabled: false
+Style/SingleArgumentDig:
+  Enabled: false
+Style/SlicingWithRange:
+  Enabled: false
+Style/SoleNestedConditional:
+  Enabled: false
+Style/StderrPuts:
+  Enabled: false
+Style/StringConcatenation:
+  Enabled: false
+Style/Strip:
+  Enabled: false
 Style/SymbolProc:
+  Enabled: false
+Style/TrailingBodyOnClass:
+  Enabled: false
+Style/TrailingBodyOnMethodDefinition:
+  Enabled: false
+Style/TrailingBodyOnModule:
+  Enabled: false
+Style/TrailingCommaInHashLiteral:
+  Enabled: false
+Style/TrailingMethodEndStatement:
+  Enabled: false
+Style/UnpackFirst:
+  Enabled: false
+Lint/DuplicateBranch:
+  Enabled: false
+Lint/DuplicateRegexpCharacterClassElement:
+  Enabled: false
+Lint/EmptyBlock:
+  Enabled: false
+Lint/EmptyClass:
+  Enabled: false
+Lint/NoReturnInBeginEndBlocks:
+  Enabled: false
+Lint/ToEnumArguments:
+  Enabled: false
+Lint/UnexpectedBlockArity:
+  Enabled: false
+Lint/UnmodifiedReduceAccumulator:
+  Enabled: false
+Performance/CollectionLiteralInLoop:
+  Enabled: false
+Style/ArgumentsForwarding:
+  Enabled: false
+Style/CollectionCompact:
+  Enabled: false
+Style/DocumentDynamicEvalDefinition:
+  Enabled: false
+Style/NegatedIfElseCondition:
+  Enabled: false
+Style/NilLambda:
+  Enabled: false
+Style/RedundantArgument:
+  Enabled: false
+Style/SwapValues:
   Enabled: false

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,29 +1,14 @@
 ---
 .github/workflows/ci.yaml:
-  unit_name: Puppet ${{ matrix.puppet }} (Ruby ${{ matrix.ruby }} fixtures=${{ matrix.fixtures }})
-  unit_includes:
-    - ruby: '2.4.9'
-      puppet: '5'
-      fixtures: .fixtures.yml
-      allow_failure: false
-    - ruby: '2.5.7'
-      puppet: '6'
-      fixtures: .fixtures-latest.yml
-      allow_failure: true
-    - ruby: '2.7.0'
-      puppet: '7'
-      fixtures: .fixtures-latest.yml
-      allow_failure: true
   acceptance_matrix:
     set:
-      - centos-7
-      - centos-8
-      - debian-9
-      - debian-10
-      - ubuntu-1804
+      - el8
+      - el9
+      - debian-11
+      - ubuntu-2004
     puppet:
-      - puppet6
       - puppet7
+      - puppet8
 .travis.yml:
   delete: true
 Rakefile:
@@ -31,10 +16,4 @@ Rakefile:
 .gitlab-ci.yml:
   delete: true
 appveyor.yml:
-  delete: true
-spec/acceptance/nodesets/centos-6.yml:
-  delete: true
-spec/acceptance/nodesets/debian-8.yml:
-  delete: true
-spec/acceptance/nodesets/ubuntu-1604.yml:
   delete: true

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "puppet.puppet-vscode",
+    "rebornix.Ruby"
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,4 +3,4 @@
 1. Update metadata.json version, eg: `pdk bundle exec rake module:bump:{major,minor,patch}`
 1. Run release task, eg: `pdk bundle exec rake release`
 1. Update GitHub pages, eg: `pdk bundle exec rake strings:gh_pages:update`
-1. Push to GitHub: `git push --tags origin master`
+1. Push to GitHub: `git push --tags origin main`

--- a/Gemfile
+++ b/Gemfile
@@ -17,31 +17,23 @@ ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
 minor_version = ruby_version_segments[0..1].join('.')
 
 group :development do
-  gem "facter", '< 4.0',                                         require: false
-  gem "fast_gettext", '1.1.0',                                   require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
-  gem "fast_gettext",                                            require: false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
-  gem "json_pure", '<= 2.0.1',                                   require: false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.0.0')
-  gem "json", '= 1.8.1',                                         require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.1.9')
-  gem "json", '= 2.0.4',                                         require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.1.0',                                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "rb-readline", '= 0.5.5',                                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-module-posix-default-r#{minor_version}", '~> 0.4', require: false, platforms: [:ruby]
-  gem "puppet-module-posix-dev-r#{minor_version}", '~> 0.4',     require: false, platforms: [:ruby]
-  gem "puppet-module-win-default-r#{minor_version}", '~> 0.4',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-module-win-dev-r#{minor_version}", '~> 0.4',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-lint-param-docs",                                  require: false
-  gem "github_changelog_generator",                              require: false, git: 'https://github.com/skywinder/github-changelog-generator', ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018' if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')
+  gem "voxpupuli-test", '6.0.0',        require: false
+  gem "rubocop-performance", '~> 1.18', require: false
+  gem "faraday", '~> 1.0',              require: false
+  gem "github_changelog_generator",     require: false
+  gem "puppet-blacksmith",              require: false
+  gem "puppet-strings",                 require: false
 end
 group :system_tests do
-  gem "puppet-module-posix-system-r#{minor_version}", '~> 0.5',                  require: false, platforms: [:ruby]
-  gem "puppet-module-win-system-r#{minor_version}", '~> 0.5',                    require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 4.0')
+  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 4.29')
   gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')
   gem "beaker-pe",                                                               require: false
   gem "beaker-hostgenerator"
   gem "beaker-rspec"
   gem "beaker-docker"
   gem "beaker-puppet"
+  gem "beaker-puppet_install_helper",                                            require: false
+  gem "beaker-module_install_helper",                                            require: false
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']
@@ -59,16 +51,6 @@ gems['puppet'] = location_for(puppet_version)
 
 gems['facter'] = location_for(facter_version) if facter_version
 gems['hiera'] = location_for(hiera_version) if hiera_version
-
-if Gem.win_platform? && puppet_version =~ %r{^(file:///|git://)}
-  # If we're using a Puppet gem on Windows which handles its own win32-xxx gem
-  # dependencies (>= 3.5.0), set the maximum versions (see PUP-6445).
-  gems['win32-dir'] =      ['<= 0.4.9', require: false]
-  gems['win32-eventlog'] = ['<= 0.6.5', require: false]
-  gems['win32-process'] =  ['<= 0.7.5', require: false]
-  gems['win32-security'] = ['<= 0.2.5', require: false]
-  gems['win32-service'] =  ['0.8.8', require: false]
-end
 
 gems.each do |gem_name, gem_params|
   gem gem_name, *gem_params

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require 'puppet_litmus/rake_tasks' if Bundler.rubygems.find_name('puppet_litmus').any?
+require 'bundler'
+require 'beaker-rspec/rake_task' if Bundler.rubygems.find_name('beaker-rspec').any?
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-syntax/tasks/puppet-syntax'
 require 'puppet_blacksmith/rake_tasks' if Bundler.rubygems.find_name('puppet-blacksmith').any?
@@ -39,8 +40,12 @@ def changelog_future_release
   returnVal
 end
 
+PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.send('disable_140chars')
+PuppetLint.configuration.send('disable_manifest_whitespace_opening_brace_after')
 PuppetLint.configuration.send('disable_relative')
 PuppetLint.configuration.send('fail_on_warnings')
+
 
 if Bundler.rubygems.find_name('github_changelog_generator').any?
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|
@@ -52,7 +57,7 @@ if Bundler.rubygems.find_name('github_changelog_generator').any?
     config.header = "# Change log\n\nAll notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org)."
     config.add_pr_wo_labels = true
     config.issues = false
-    config.merge_prefix = "### UNCATEGORIZED PRS; GO LABEL THEM"
+    config.merge_prefix = "### Merged pull requests:"
     config.configure_sections = {
       "Changed" => {
         "prefix" => "### Changed",
@@ -60,11 +65,11 @@ if Bundler.rubygems.find_name('github_changelog_generator').any?
       },
       "Added" => {
         "prefix" => "### Added",
-        "labels" => ["feature", "enhancement"],
+        "labels" => ["enhancement", "feature"],
       },
       "Fixed" => {
         "prefix" => "### Fixed",
-        "labels" => ["bugfix"],
+        "labels" => ["bug", "documentation", "bugfix"],
       },
     }
   end
@@ -72,16 +77,15 @@ else
   desc 'Generate a Changelog from GitHub'
   task :changelog do
     raise <<EOM
-The changelog tasks depends on unreleased features of the github_changelog_generator gem.
+The changelog tasks depends on recent features of the github_changelog_generator gem.
 Please manually add it to your .sync.yml for now, and run `pdk update`:
 ---
 Gemfile:
   optional:
     ':development':
       - gem: 'github_changelog_generator'
-        git: 'https://github.com/skywinder/github-changelog-generator'
-        ref: '20ee04ba1234e9e83eb2ffb5056e23d641c7a018'
-        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.2.2')"
+        version: '~> 1.15'
+        condition: "Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.3.0')"
 EOM
   end
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,10 +57,9 @@ class etcd (
   String[1] $group = 'etcd',
   Optional[Integer] $group_gid = undef,
   Stdlib::Absolutepath $config_path = '/etc/etcd.yaml',
-  Hash $config = {'data-dir' => '/var/lib/etcd'},
+  Hash $config = { 'data-dir' => '/var/lib/etcd' },
   Integer $max_open_files = 40000,
 ) {
-
   if $os != 'linux' {
     fail("Module etcd only supports Linux, not ${os}")
   }
@@ -100,7 +99,7 @@ class etcd (
     before          => [
       File['etcd'],
       File['etcdctl'],
-    ]
+    ],
   }
 
   file { 'etcd':

--- a/metadata.json
+++ b/metadata.json
@@ -10,67 +10,53 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 6.0.0 <7.0.0"
+      "version_requirement": ">= 6.0.0 <10.0.0"
     },
     {
       "name": "puppet/archive",
-      "version_requirement": ">= 4.0.0 <5.0.0"
+      "version_requirement": ">= 7.0.0 <8.0.0"
     },
     {
-      "name": "camptocamp/systemd",
-      "version_requirement": ">= 2.0.0 <3.0.0"
+      "name": "puppet/systemd",
+      "version_requirement": ">= 5.0.0 <7.0.0"
     }
   ],
   "operatingsystem_support": [
     {
-      "operatingsystem": "CentOS",
-      "operatingsystemrelease": [
-        "7",
-        "8"
-      ]
-    },
-    {
-      "operatingsystem": "OracleLinux",
-      "operatingsystemrelease": [
-        "7",
-        "8"
-      ]
-    },
-    {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
-      "operatingsystem": "Scientific",
+      "operatingsystem": "Rocky",
       "operatingsystemrelease": [
-        "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "9",
-        "10"
+        "11"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "18.04"
+        "20.04",
+        "22.04"
       ]
     }
   ],
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.5.10 < 8.0.0"
+      "version_requirement": ">= 7.0.0 < 9.0.0"
     }
   ],
-  "pdk-version": "1.18.1",
-  "template-url": "https://github.com/tailored-automation/pdk-templates.git#master",
-  "template-ref": "heads/master-0-g2163167"
+  "pdk-version": "3.0.0",
+  "template-url": "https://github.com/tailored-automation/pdk-templates.git#main",
+  "template-ref": "heads/main-0-g53868f7"
 }

--- a/spec/acceptance/nodesets/debian-11.yml
+++ b/spec/acceptance/nodesets/debian-11.yml
@@ -1,10 +1,10 @@
 HOSTS:
-  debian10:
+  debian11:
     roles:
       - agent
-    platform: debian-10-amd64
+    platform: debian-11-amd64
     hypervisor: docker
-    image: debian:10
+    image: debian:11
     docker_preserve_image: true
     docker_cmd:
       - '/sbin/init'
@@ -14,11 +14,14 @@ HOSTS:
       - 'echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen'
       - 'echo "LANG=en_US.UTF-8" > /etc/locale.conf'
       - 'locale-gen en_US.UTF-8'
-    docker_container_name: 'etcd-debian10'
+    docker_env:
+      - LANG=en_US.UTF-8
+      - LANGUAGE=en_US.UTF-8
+      - LC_ALL=en_US.UTF-8
+    docker_container_name: 'etcd-debian11'
 CONFIG:
   log_level: debug
   type: foss
 ssh:
   password: root
   auth_methods: ["password"]
-

--- a/spec/acceptance/nodesets/el8.yml
+++ b/spec/acceptance/nodesets/el8.yml
@@ -1,17 +1,21 @@
 HOSTS:
-  centos-8:
+  el8:
     roles:
       - agent
     platform: el-8-x86_64
     hypervisor: docker
-    image: centos:8
+    image: almalinux:8
     docker_preserve_image: true
     docker_cmd:
       - '/usr/sbin/init'
     docker_image_commands:
-      - 'yum install -y dnf-utils'
+      - 'dnf install -y dnf-utils'
       - 'dnf config-manager --set-enabled powertools'
-      - 'yum install -y wget which cronie iproute initscripts'
+      - 'dnf install -y wget which cronie iproute initscripts'
+    docker_env:
+      - LANG=en_US.UTF-8
+      - LANGUAGE=en_US.UTF-8
+      - LC_ALL=en_US.UTF-8
     docker_container_name: 'etcd-el8'
 CONFIG:
   log_level: debug
@@ -19,4 +23,3 @@ CONFIG:
 ssh:
   password: root
   auth_methods: ["password"]
-

--- a/spec/acceptance/nodesets/el9.yml
+++ b/spec/acceptance/nodesets/el9.yml
@@ -1,0 +1,25 @@
+HOSTS:
+  el9:
+    roles:
+      - agent
+    platform: el-9-x86_64
+    hypervisor: docker
+    image: almalinux:9
+    docker_preserve_image: true
+    docker_cmd:
+      - '/usr/sbin/init'
+    docker_image_commands:
+      - 'dnf install -y dnf-utils'
+      - 'dnf config-manager --set-enabled crb'
+      - 'dnf install -y wget which cronie iproute initscripts'
+    docker_env:
+      - LANG=en_US.UTF-8
+      - LANGUAGE=en_US.UTF-8
+      - LC_ALL=en_US.UTF-8
+    docker_container_name: 'etcd-el9'
+CONFIG:
+  log_level: debug
+  type: foss
+ssh:
+  password: root
+  auth_methods: ["password"]

--- a/spec/acceptance/nodesets/ubuntu-2004.yml
+++ b/spec/acceptance/nodesets/ubuntu-2004.yml
@@ -1,0 +1,24 @@
+HOSTS:
+  ubuntu2004:
+    roles:
+      - agent
+    platform: ubuntu-20.04-amd64
+    hypervisor : docker
+    image: ubuntu:20.04
+    docker_preserve_image: true
+    docker_cmd: '["/sbin/init"]'
+    docker_image_commands:
+      - "rm -f /etc/dpkg/dpkg.cfg.d/excludes"
+      - 'apt-get install -y wget net-tools iproute2 locales apt-transport-https ca-certificates'
+      - 'locale-gen en_US.UTF-8'
+    docker_env:
+      - LANG=en_US.UTF-8
+      - LANGUAGE=en_US.UTF-8
+      - LC_ALL=en_US.UTF-8
+    docker_container_name: 'etcd-ubuntu2004'
+CONFIG:
+  log_level: debug
+  type: foss
+ssh:
+  password: root
+  auth_methods: ["password"]

--- a/spec/acceptance/nodesets/ubuntu-2204.yml
+++ b/spec/acceptance/nodesets/ubuntu-2204.yml
@@ -1,21 +1,24 @@
 HOSTS:
-  ubuntu1804:
+  ubuntu2204:
     roles:
       - agent
-    platform: ubuntu-18.04-amd64
+    platform: ubuntu-22.04-amd64
     hypervisor : docker
-    image: ubuntu:18.04
+    image: ubuntu:22.04
     docker_preserve_image: true
     docker_cmd: '["/sbin/init"]'
     docker_image_commands:
       - "rm -f /etc/dpkg/dpkg.cfg.d/excludes"
-      - 'apt-get install -y wget net-tools locales apt-transport-https ca-certificates'
+      - 'apt-get install -y wget net-tools iproute2 locales apt-transport-https ca-certificates'
       - 'locale-gen en_US.UTF-8'
-    docker_container_name: 'etcd-ubuntu1804'
+    docker_env:
+      - LANG=en_US.UTF-8
+      - LANGUAGE=en_US.UTF-8
+      - LC_ALL=en_US.UTF-8
+    docker_container_name: 'etcd-ubuntu2204'
 CONFIG:
   log_level: debug
   type: foss
 ssh:
   password: root
   auth_methods: ["password"]
-

--- a/spec/classes/etcd_spec.rb
+++ b/spec/classes/etcd_spec.rb
@@ -3,7 +3,11 @@ require 'spec_helper'
 describe 'etcd' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
-      let(:facts) { os_facts }
+      # Debian 11 fails to set arch so stub here
+      let(:facts) do
+        os_facts[:os]['architecture'] = 'x86_64'
+        os_facts
+      end
 
       it { is_expected.to compile.with_all_deps }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,7 @@ default_fact_files.each do |f|
   next unless File.exist?(f) && File.readable?(f) && File.size?(f)
 
   begin
-    default_facts.merge!(YAML.safe_load(File.read(f), [], [], true))
+    default_facts.merge!(YAML.safe_load(File.read(f)))
   rescue => e
     RSpec.configuration.reporter.message "WARNING: Unable to load #{f}: #{e}"
   end
@@ -46,6 +46,18 @@ RSpec.configure do |c|
   end
   c.filter_run_excluding(bolt: true) unless ENV['GEM_BOLT']
   c.after(:suite) do
+  end
+
+  # Filter backtrace noise
+  backtrace_exclusion_patterns = [
+    %r{spec_helper},
+    %r{gems},
+  ]
+
+  if c.respond_to?(:backtrace_exclusion_patterns)
+    c.backtrace_exclusion_patterns = backtrace_exclusion_patterns
+  elsif c.respond_to?(:backtrace_clean_patterns)
+    c.backtrace_clean_patterns = backtrace_exclusion_patterns
   end
 end
 


### PR DESCRIPTION
Support Puppet 7 and Puppet 8 only
Support newer module dependencies
Drop EL7, Debian 9, Debian 10 and Ubuntu 18.04 support 
Add EL9, Debian 11, Ubuntu 20.04 and Ubuntu 22.04 support