### PR TITLE
Deprecations

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -145,7 +145,7 @@ class etcd (
     owner   => $user,
     group   => $group,
     mode    => '0600',
-    content => to_yaml($config),
+    content => stdlib::to_yaml($config),
     notify  => Service['etcd'],
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 6.0.0 <10.0.0"
+      "version_requirement": ">= 9.0.0 <10.0.0"
     },
     {
       "name": "puppet/archive",


### PR DESCRIPTION
`to_yaml` is deprecated for `stdlib >= 9.0` 